### PR TITLE
Generate Azure entry file when deploy.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,5 +27,6 @@ build/Release
 # https://docs.npmjs.com/misc/faq#should-i-check-my-node-modules-folder-into-git
 node_modules
 
-# Distribution directory
+# Generated directories and files
 dist
+server.js

--- a/deploy/azure-tasks.js
+++ b/deploy/azure-tasks.js
@@ -1,0 +1,19 @@
+import fs from 'fs';
+import path from 'path';
+import gulp from 'gulp';
+import mkdirp from 'mkdirp';
+
+function writeFile(filePath, content) {
+  const fileDir = path.dirname(filePath);
+  return new Promise((resolve, reject) =>
+    mkdirp(fileDir, error =>
+      error ? reject(error) : fs.writeFile(filePath, content, resolve)));
+}
+
+function generateServer() {
+  const serverPath = path.resolve(__dirname, '../server.js');
+  const content = 'require("./dist/index");';
+  return writeFile(serverPath, content);
+}
+
+gulp.task('azure-tasks', () => generateServer());

--- a/deploy/azure.sh
+++ b/deploy/azure.sh
@@ -113,7 +113,7 @@ selectNodeVersion
 if [ -e "$DEPLOYMENT_TARGET/package.json" ]; then
   cd "$DEPLOYMENT_TARGET"
   eval $NPM_CMD install
-  eval $NPM_CMD run build
+  eval $NPM_CMD run deploy-azure
   exitWithMessageOnError "npm failed"
   cd - > /dev/null
 fi

--- a/deploy/azure.sh
+++ b/deploy/azure.sh
@@ -78,7 +78,7 @@ selectNodeVersion () {
       exitWithMessageOnError "getting node version failed"
     fi
 
-    if [[ -e "$DEPLOYMENT_TEMP/.tmp" ]]; then
+    if [[ -e "$DEPLOYMENT_TEMP/__npmVersion.tmp" ]]; then
       NPM_JS_PATH=`cat "$DEPLOYMENT_TEMP/__npmVersion.tmp"`
       exitWithMessageOnError "getting npm version failed"
     fi

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,6 +2,8 @@ import gulp from 'gulp';
 import eslint from 'gulp-eslint';
 import babel from 'gulp-babel';
 
+import './deploy/azure-tasks';
+
 gulp.task('lint', () =>
   gulp.src(['gulpfile.js', 'src/**/*.js'])
     .pipe(eslint())
@@ -13,4 +15,6 @@ gulp.task('transform', () =>
     .pipe(babel())
     .pipe(gulp.dest('dist')));
 
-gulp.task('default', ['lint', 'transform']);
+gulp.task('build', ['lint', 'transform']);
+
+gulp.task('deploy-azure', ['build', 'azure-tasks']);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "repository": "https://github.com/lijunle/depcheck-web",
   "license": "MIT",
   "scripts": {
-    "build": "babel-node ./node_modules/gulp/bin/gulp.js",
+    "build": "babel-node ./node_modules/gulp/bin/gulp.js build",
+    "deploy-azure": "babel-node ./node_modules/gulp/bin/gulp.js deploy-azure",
     "local": "babel-node ./src/index.js"
   },
   "engines": {
@@ -21,6 +22,7 @@
     "eslint-config-airbnb": "^0.1.0",
     "gulp": "^3.9.0",
     "gulp-babel": "^5.2.1",
-    "gulp-eslint": "^1.0.0"
+    "gulp-eslint": "^1.0.0",
+    "mkdirp": "^0.5.1"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,1 +1,0 @@
-require('./dist/index');


### PR DESCRIPTION
- Add deploy-azure task to contain Azure deployment relative works.
- Leverage deploy-azure task in Azure deployment script
- Add `generateServer` task to generate `server.js` file.
- Remove `server.js` file from git repository.
- Fix get NPM version bug in deployment script.