### PR TITLE
Move the queue trigger outside of services folder.

### DIFF
--- a/build/azure.js
+++ b/build/azure.js
@@ -17,7 +17,7 @@ gulp.task('azure:generate-server', ['azure:clean'], () => {
 
 gulp.task('azure:generate-job', ['azure:clean'], () => {
   const nodePath = path.resolve(__dirname, '../node.cmd');
-  const jobPath = path.resolve(__dirname, '../dist/job.js');
+  const jobPath = path.resolve(__dirname, '../dist/job/index.js');
   const runPath = path.resolve(__dirname, '../App_Data/jobs/continuous/depcheck/run.cmd');
   const content = `"${nodePath}" "${jobPath}"`;
   return writeFile(runPath, content);

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "babel-node ./node_modules/gulp/bin/gulp.js build",
     "build-azure": "babel-node ./node_modules/gulp/bin/gulp.js build-azure",
     "local": "babel-node ./src/index.js",
-    "job": "babel-node ./src/job.js"
+    "job": "babel-node ./src/job/index.js"
   },
   "engines": {
     "node": "4.x",

--- a/src/job/index.js
+++ b/src/job/index.js
@@ -1,6 +1,7 @@
-import { logger, table, job } from './services';
+import queueTrigger from './queue-trigger';
+import { logger, table } from '../services';
 
-job.execute('ping', message => {
+queueTrigger('ping', message => {
   logger.info(`Get message [${message}], pong back.`);
 
   return table.insert('ping', {

--- a/src/job/queue-trigger.js
+++ b/src/job/queue-trigger.js
@@ -25,6 +25,8 @@ function handle(error, query) {
 export default function trigger(queueName, fn) {
   function query() {
     logger.debug(`Start query on the queue [${queueName}].`);
+
+    // TODO update the queue trigger to be safe for concurrency.
     queue.peek(queueName)
     .then(message => process(message, fn))
     .then(message => queue.remove(queueName, message))

--- a/src/job/queue-trigger.js
+++ b/src/job/queue-trigger.js
@@ -1,5 +1,4 @@
-import * as queue from './queue';
-import * as logger from './logger';
+import { logger, queue } from '../services';
 
 function process(message, fn) {
   if (!message) {
@@ -23,7 +22,7 @@ function handle(error, query) {
   setTimeout(query, interval);
 }
 
-export function execute(queueName, fn) {
+export default function trigger(queueName, fn) {
   function query() {
     logger.debug(`Start query on the queue [${queueName}].`);
     queue.peek(queueName)

--- a/src/services/azure/index.js
+++ b/src/services/azure/index.js
@@ -1,10 +1,8 @@
-import * as job from './job';
 import * as logger from './logger';
 import * as queue from './queue';
 import * as table from './table';
 
 export default {
-  job,
   logger,
   queue,
   table,


### PR DESCRIPTION
- Move the queue trigger file to `job` folder.
- Move the `job.js` inside `job` folder too.
- The queue trigger can be shared acrss different services.
- Update the entry script and build script.
- Add a TODO in queue trigger: update the queue trigger to be safe for concurrency.