### PR TITLE
Convert report SVG route to routes pattern.

### DIFF
--- a/src/controllers/index.js
+++ b/src/controllers/index.js
@@ -15,11 +15,6 @@ router.get('/:provider/:user', loginModel.validate, (req, res) =>
   .then(result => res.render('repo-list', result),
     error => res.send(error)));
 
-// must place the svg router before the next one.
-router.get('/:provider/:user/:repo/:branch/:report?.svg', (req, res) =>
-  reportModel.get(req.params)
-  .then(result => res.type('svg').render('badge', result)));
-
 router.route('/:provider/:user/:repo/:report?')
   .get(loginModel.validate, (req, res) =>
     reportModel.query(req.params)

--- a/src/controllers/index.js
+++ b/src/controllers/index.js
@@ -18,6 +18,12 @@ router.get('/:provider/:user', loginModel.validate, (req, res) =>
 router.route('/:provider/:user/:repo/:report?')
   .get(loginModel.validate, (req, res) =>
     reportModel.query(req.params)
+    .then(result => ({
+      provider: req.params.provider,
+      user: req.params.user,
+      repo: req.params.repo,
+      reports: result,
+    }))
     .then(result => res.render('repo', result),
       error => res.send(error)))
   .post(jsonParser, (req, res) =>

--- a/src/models/report.js
+++ b/src/models/report.js
@@ -17,6 +17,7 @@ export function query({ provider, user, repo }) {
   }));
 }
 
+// TODO need refactor to merge with query function
 export function get(params) {
   logger.debug(`[model:report] get report with parameter ${JSON.stringify(params)}.`);
   const { branch, report = '' } = params;

--- a/src/models/report.js
+++ b/src/models/report.js
@@ -1,31 +1,16 @@
 import { logger, table } from '../services';
 
-export function query({ provider, user, repo }) {
-  logger.debug(`[model:report] query reports with provider [${provider}], user [${user}] and repo [${repo}].`);
-  return table.query('report', {
-    filter: { provider, user, repo },
-  }).then(result => ({
-    provider,
-    user,
-    repo,
-    reports: result.map(item => ({
-      branch: item.branch,
-      report: item.report,
-      dependencies: JSON.parse(item.dependencies),
-      devDependencies: JSON.parse(item.devDependencies),
-    })),
-  }));
-}
+export function query(filter) {
+  logger.debug(`[model:report] query reports with filter ${JSON.stringify(filter)}.`);
 
-// TODO need refactor to merge with query function
-export function get(params) {
-  logger.debug(`[model:report] get report with parameter ${JSON.stringify(params)}.`);
-  const { branch, report = '' } = params;
-  return query(params)
-  .then(result =>
-    result.reports.filter(its =>
-      its.branch === branch && its.report === report))
-  .then(([first]) => first || {});
+  return table.query('report', { filter })
+  .then(reports =>
+    reports.map(report => ({
+      branch: report.branch,
+      report: report.report,
+      dependencies: JSON.parse(report.dependencies),
+      devDependencies: JSON.parse(report.devDependencies),
+    })));
 }
 
 export function upsert({ provider, user, repo, branch, report, result }) {

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -9,6 +9,7 @@ const routes = [
   'login',
   'login/callback',
   'token',
+  'report/svg', // must place the svg router before report/index.
 ];
 
 routes.forEach(name => {
@@ -30,7 +31,8 @@ routes.forEach(name => {
       module.redirect(req).then(url => res.redirect(url)));
   } else if (module.view && module.model) {
     route.get((req, res) =>
-      module.model(req).then(model => res.render(module.view, model)));
+      module.model(req).then(model =>
+        res.type(module.type || 'html').render(module.view, model)));
   } else {
     route.get((req, res) =>
       res.status(500).end());

--- a/src/routes/report/svg.js
+++ b/src/routes/report/svg.js
@@ -1,0 +1,11 @@
+import * as reportModel from '../../models/report';
+
+export const route = '/:provider/:user/:repo/:branch/:report?.svg';
+
+export const type = 'svg';
+
+export const view = 'badge';
+
+export function model({ params }) {
+  return reportModel.get(params);
+}

--- a/src/routes/report/svg.js
+++ b/src/routes/report/svg.js
@@ -1,3 +1,4 @@
+import { logger } from '../../services';
 import * as reportModel from '../../models/report';
 
 export const route = '/:provider/:user/:repo/:branch/:report?.svg';
@@ -17,7 +18,12 @@ function toViewModel(report) {
 }
 
 export function model({ params }) {
-  return reportModel.get(params)
+  logger.debug(`[routes:report:svg] get report SVG view model with parameter ${JSON.stringify(params)}.`);
+
+  params.report = params.report || '';
+
+  return reportModel.query(params)
+  .then(([first]) => first || {})
   .then(report => toViewModel(report))
   .then(([caption, color]) => ({ caption, color }));
 }

--- a/src/routes/report/svg.js
+++ b/src/routes/report/svg.js
@@ -6,6 +6,18 @@ export const type = 'svg';
 
 export const view = 'badge';
 
+function toViewModel(report) {
+  if (!report.dependencies || !report.devDependencies) {
+    return ['unknown', '#9f9f9f'];
+  } else if (report.dependencies.length || report.devDependencies.length) {
+    return ['failing', '#e05d44'];
+  }
+
+  return ['passing', '#4c1'];
+}
+
 export function model({ params }) {
-  return reportModel.get(params);
+  return reportModel.get(params)
+  .then(report => toViewModel(report))
+  .then(([caption, color]) => ({ caption, color }));
 }

--- a/src/routes/report/svg.js
+++ b/src/routes/report/svg.js
@@ -7,10 +7,10 @@ export const type = 'svg';
 
 export const view = 'badge';
 
-function toViewModel(report) {
-  if (!report.dependencies || !report.devDependencies) {
+function toViewModel({ dependencies, devDependencies }) {
+  if (!dependencies || !devDependencies) {
     return ['unknown', '#9f9f9f'];
-  } else if (report.dependencies.length || report.devDependencies.length) {
+  } else if (dependencies.length || devDependencies.length) {
     return ['failing', '#e05d44'];
   }
 
@@ -24,6 +24,6 @@ export function model({ params }) {
 
   return reportModel.query(params)
   .then(([first]) => first || {})
-  .then(report => toViewModel(report))
+  .then(toViewModel)
   .then(([caption, color]) => ({ caption, color }));
 }

--- a/src/services/azure/table.js
+++ b/src/services/azure/table.js
@@ -19,6 +19,7 @@ function buildTableQuery({ limit, filter }) {
 
   if (typeof filter === 'object') {
     const condition = Object.keys(filter)
+      .filter(key => filter[key] !== undefined)
       .map(key => `${key} eq ${serializeQueryValue(filter[key])}`)
       .join(' and ');
 

--- a/src/views/badge.js
+++ b/src/views/badge.js
@@ -1,19 +1,7 @@
 import React from 'react';
 
-function getSettings(result) {
-  if (!result.dependencies || !result.devDependencies) {
-    return ['unknown', '#9f9f9f'];
-  } else if (result.dependencies.length || result.devDependencies.length) {
-    return ['failing', '#e05d44'];
-  }
-
-  return ['passing', '#4c1'];
-}
-
 export default React.createClass({
   render() {
-    // TODO expand the badge width according to caption
-    const [caption, color] = getSettings(this.props);
     return (
       <svg width="103" height="20">
         <linearGradient id="a" x2="0" y2="100%">
@@ -21,8 +9,8 @@ export default React.createClass({
           <stop offset="1" stopOpacity=".1" />
         </linearGradient>
         <rect rx="3" width="103" height="20" fill="#555" />
-        <rect rx="3" x="56" width="47" height="20" fill={color} />
-        <path fill={color} d="M56 0h4v20h-4z" />
+        <rect rx="3" x="56" width="47" height="20" fill={this.props.color} />
+        <path fill={this.props.color} d="M56 0h4v20h-4z" />
         <rect rx="3" width="103" height="20" fill="url(#a)" />
         <g
           fill="#fff"
@@ -32,8 +20,8 @@ export default React.createClass({
         >
           <text x="28" y="15" fill="#010101" fillOpacity=".3">depcheck</text>
           <text x="28" y="14">depcheck</text>
-          <text x="79" y="15" fill="#010101" fillOpacity=".3">{caption}</text>
-          <text x="79" y="14">{caption}</text>
+          <text x="79" y="15" fill="#010101" fillOpacity=".3">{this.props.caption}</text>
+          <text x="79" y="14">{this.props.caption}</text>
         </g>
       </svg>
     );

--- a/test/e2e/report/svg.js
+++ b/test/e2e/report/svg.js
@@ -1,0 +1,99 @@
+/* global describe, it */
+
+import stub from '../../utils/stub';
+
+function tableQuery(records) {
+  const calls = [];
+
+  function query(tableName, { filter }) {
+    calls.push({ tableName, filter });
+    return Promise.resolve(records);
+  }
+
+  query.calls = calls;
+  return query;
+}
+
+describe('/provider/user/repo/branch.svg', () => {
+  it('should get a passing badge for report without unused dependencies', done => {
+    const query = tableQuery([{
+      provider: 'e2e',
+      user: 'tester',
+      repo: 'project',
+      branch: 'master',
+      report: '',
+      dependencies: JSON.stringify([]),
+      devDependencies: JSON.stringify([]),
+    }]);
+
+    stub({
+      table: { query },
+    })
+    .get('/e2e/tester/project/master.svg')
+    .expect(200)
+    .expect(res => res.text = res.body.toString('utf8'))
+    .expect(/^<svg/)
+    .expect(/>passing</)
+    .expect(() => {
+      query.calls[0].tableName.should.equal('report');
+      query.calls[0].filter.should.have.properties({
+        provider: 'e2e',
+        user: 'tester',
+        repo: 'project',
+      });
+    })
+    .end(done);
+  });
+
+  it('should get a failing badge for report with unused dependencies', done => {
+    const query = tableQuery([{
+      provider: 'e2e',
+      user: 'tester',
+      repo: 'project',
+      branch: 'failing',
+      report: '',
+      dependencies: JSON.stringify(['unused-dep']),
+      devDependencies: JSON.stringify([]),
+    }]);
+
+    stub({
+      table: { query },
+    })
+    .get('/e2e/tester/project/failing.svg')
+    .expect(200)
+    .expect(res => res.text = res.body.toString('utf8'))
+    .expect(/^<svg/)
+    .expect(/>failing</)
+    .expect(() => {
+      query.calls[0].tableName.should.equal('report');
+      query.calls[0].filter.should.have.properties({
+        provider: 'e2e',
+        user: 'tester',
+        repo: 'project',
+      });
+    })
+    .end(done);
+  });
+
+  it('should get an unknown badge for report which not exists', done => {
+    const query = tableQuery([]);
+
+    stub({
+      table: { query },
+    })
+    .get('/e2e/tester/project/unknown.svg')
+    .expect(200)
+    .expect(res => res.text = res.body.toString('utf8'))
+    .expect(/^<svg/)
+    .expect(/>unknown</)
+    .expect(() => {
+      query.calls[0].tableName.should.equal('report');
+      query.calls[0].filter.should.have.properties({
+        provider: 'e2e',
+        user: 'tester',
+        repo: 'project',
+      });
+    })
+    .end(done);
+  });
+});

--- a/test/e2e/report/svg.js
+++ b/test/e2e/report/svg.js
@@ -1,22 +1,11 @@
 /* global describe, it */
 
 import stub from '../../utils/stub';
-
-function tableQuery(records) {
-  const calls = [];
-
-  function query(tableName, { filter }) {
-    calls.push({ tableName, filter });
-    return Promise.resolve(records);
-  }
-
-  query.calls = calls;
-  return query;
-}
+import mockFunction from '../../utils/mock-function';
 
 describe('/provider/user/repo/branch.svg', () => {
   it('should get a passing badge for report without unused dependencies', done => {
-    const query = tableQuery([{
+    const query = mockFunction([{
       provider: 'e2e',
       user: 'tester',
       repo: 'project',
@@ -35,8 +24,8 @@ describe('/provider/user/repo/branch.svg', () => {
     .expect(/^<svg/)
     .expect(/>passing</)
     .expect(() => {
-      query.calls[0].tableName.should.equal('report');
-      query.calls[0].filter.should.have.properties({
+      query.calls[0][0].should.equal('report');
+      query.calls[0][1].filter.should.have.properties({
         provider: 'e2e',
         user: 'tester',
         repo: 'project',
@@ -46,7 +35,7 @@ describe('/provider/user/repo/branch.svg', () => {
   });
 
   it('should get a failing badge for report with unused dependencies', done => {
-    const query = tableQuery([{
+    const query = mockFunction([{
       provider: 'e2e',
       user: 'tester',
       repo: 'project',
@@ -65,8 +54,8 @@ describe('/provider/user/repo/branch.svg', () => {
     .expect(/^<svg/)
     .expect(/>failing</)
     .expect(() => {
-      query.calls[0].tableName.should.equal('report');
-      query.calls[0].filter.should.have.properties({
+      query.calls[0][0].should.equal('report');
+      query.calls[0][1].filter.should.have.properties({
         provider: 'e2e',
         user: 'tester',
         repo: 'project',
@@ -76,7 +65,7 @@ describe('/provider/user/repo/branch.svg', () => {
   });
 
   it('should get an unknown badge for report which not exists', done => {
-    const query = tableQuery([]);
+    const query = mockFunction([]);
 
     stub({
       table: { query },
@@ -87,8 +76,8 @@ describe('/provider/user/repo/branch.svg', () => {
     .expect(/^<svg/)
     .expect(/>unknown</)
     .expect(() => {
-      query.calls[0].tableName.should.equal('report');
-      query.calls[0].filter.should.have.properties({
+      query.calls[0][0].should.equal('report');
+      query.calls[0][1].filter.should.have.properties({
         provider: 'e2e',
         user: 'tester',
         repo: 'project',

--- a/test/e2e/report/svg.js
+++ b/test/e2e/report/svg.js
@@ -59,6 +59,8 @@ describe('/provider/user/repo/branch.svg', () => {
         provider: 'e2e',
         user: 'tester',
         repo: 'project',
+        branch: 'failing',
+        report: '',
       });
     })
     .end(done);
@@ -81,6 +83,7 @@ describe('/provider/user/repo/branch.svg', () => {
         provider: 'e2e',
         user: 'tester',
         repo: 'project',
+        report: '',
       });
     })
     .end(done);

--- a/test/e2e/token/index.js
+++ b/test/e2e/token/index.js
@@ -1,26 +1,25 @@
 /* global describe, it */
 
 import stub from '../../utils/stub';
+import mockFunction from '../../utils/mock-function';
 
 describe('/token/provider/user/repo', () =>
   it('should post to create a token', done => {
-    const insert = [];
+    const insert = mockFunction((tableName, record) => record);
 
     stub({
       session: {
         login: '/e2e/tester',
       },
-      table: {
-        insert,
-      },
+      table: { insert },
     })
     .post('/token/e2e/tester/project')
     .set('Referer', '/e2e/tester')
     .expect(302)
     .expect('Location', '/e2e/tester')
     .expect(() => {
-      insert[0].tableName.should.equal('token');
-      insert[0].record.should.have.properties('token')
+      insert.calls[0][0].should.equal('token');
+      insert.calls[0][1].should.have.properties('token')
         .and.have.properties({
           provider: 'e2e',
           user: 'tester',

--- a/test/fake/services.js
+++ b/test/fake/services.js
@@ -73,6 +73,7 @@ export default function fakeServices(stubs) {
         stubs.table.insert.push({ tableName, record });
         return Promise.resolve(record);
       },
+      query: (...args) => stubs.table.query(...args),
     },
   };
 }

--- a/test/fake/services.js
+++ b/test/fake/services.js
@@ -69,10 +69,7 @@ export default function fakeServices(stubs) {
     logger,
     session,
     table: {
-      insert(tableName, record) {
-        stubs.table.insert.push({ tableName, record });
-        return Promise.resolve(record);
-      },
+      insert: (...args) => stubs.table.insert(...args),
       query: (...args) => stubs.table.query(...args),
     },
   };

--- a/test/index.js
+++ b/test/index.js
@@ -30,26 +30,6 @@ describe('/provider/tester', () =>
       .expect(/other-2/)
       .end(done)));
 
-describe('/provider/tester/test-1/master.svg', () => {
-  it('should get a passing badge for report without unused dependencies', done =>
-    request(app)
-      .get('/provider/tester/test-1/master.svg')
-      .expect(200)
-      .expect(res => res.text = res.body.toString('utf8'))
-      .expect(/^<svg/)
-      .expect(/passing/)
-      .end(done));
-
-  it('should get a failing badge for report with unused dependencies', done =>
-    request(app)
-      .get('/provider/tester/test-1/master/fail.svg')
-      .expect(200)
-      .expect(res => res.text = res.body.toString('utf8'))
-      .expect(/^<svg/)
-      .expect(/failing/)
-      .end(done));
-});
-
 describe('/provider/tester/test-1', () => {
   it('should render the repo page', done =>
     request(app)

--- a/test/routes/report/svg.js
+++ b/test/routes/report/svg.js
@@ -1,0 +1,81 @@
+/* global describe, it */
+
+import 'should';
+import route from '../../utils/route';
+import mockFunction from '../../utils/mock-function';
+
+const params = {
+  provider: 'routes',
+  user: 'tester',
+  repo: 'project',
+  branch: 'master',
+};
+
+describe('route report svg', () => {
+  it('should return passing view model if no unused dependencies', () => {
+    const query = mockFunction([{
+      dependencies: [],
+      devDependencies: [],
+    }]);
+
+    const report = route('report/svg', {
+      '../../models/report': {
+        query,
+      },
+    });
+
+    return report.model({ params })
+    .then(model => model.should.have.properties({
+      caption: 'passing',
+      color: '#4c1',
+    }));
+  });
+
+  it('should return failing view model if exist unused dependencies', () => {
+    const query = mockFunction([{
+      dependencies: ['unused-dep'],
+      devDependencies: [],
+    }]);
+
+    const report = route('report/svg', {
+      '../../models/report': {
+        query,
+      },
+    });
+
+    return report.model({ params })
+    .then(model => model.should.have.properties({
+      caption: 'failing',
+      color: '#e05d44',
+    }));
+  });
+
+  it('should return unknown view model if no dependencies information', () => {
+    const query = mockFunction([]);
+    const report = route('report/svg', {
+      '../../models/report': {
+        query,
+      },
+    });
+
+    return report.model({ params })
+    .then(model => model.should.have.properties({
+      caption: 'unknown',
+      color: '#9f9f9f',
+    }));
+  });
+
+  it('should set report default value to empty string', () => {
+    const query = mockFunction([]);
+    const report = route('report/svg', {
+      '../../models/report': {
+        query,
+      },
+    });
+
+    return report.model({ params })
+    .then(() =>
+      query.calls[0][0].should.have.properties(params)
+        .and.have.property('report', ''));
+  });
+});

--- a/test/utils/mock-function.js
+++ b/test/utils/mock-function.js
@@ -3,7 +3,8 @@ export default function mockFunction(value) {
 
   function fn(...args) {
     calls.push(args);
-    return Promise.resolve(value);
+    const result = typeof value === 'function' ? value(...args) : value;
+    return Promise.resolve(result);
   }
 
   fn.calls = calls;

--- a/test/utils/mock-function.js
+++ b/test/utils/mock-function.js
@@ -1,0 +1,11 @@
+export default function mockFunction(value) {
+  const calls = [];
+
+  function fn(...args) {
+    calls.push(args);
+    return Promise.resolve(value);
+  }
+
+  fn.calls = calls;
+  return fn;
+}

--- a/test/views/badge.js
+++ b/test/views/badge.js
@@ -1,0 +1,22 @@
+/* global describe, it */
+
+import 'should';
+import view from '../utils/view';
+
+describe('view badge', () => {
+  it('should render depcheck badge with caption and color', () => {
+    const query = view('badge', {
+      caption: 'my-caption',
+      color: 'green',
+    });
+
+    query('text').eq(0).text().should.equal('depcheck');
+    query('text').eq(1).text().should.equal('depcheck');
+
+    query('text').eq(2).text().should.equal('my-caption');
+    query('text').eq(3).text().should.equal('my-caption');
+
+    query('rect').eq(1).attr('fill').should.equal('green');
+    query('path').eq(0).attr('fill').should.equal('green');
+  });
+});


### PR DESCRIPTION
- Convert report SVG route to routes pattern.
- Add E2E test case, route unit test and SVG view unit test.
- Refine the report model.
- Refine the test infrastructure.