### PR TITLE
Refine the login session validation

### DIFF
--- a/src/models/login.js
+++ b/src/models/login.js
@@ -2,30 +2,23 @@ import { logger } from '../services';
 
 export function set({ session, provider, user }) {
   logger.debug(`[model:login] set login with provider [${provider}] and user [${user}].`);
-  session.login = `/${provider}/${user}`; // TODO store login object
+  session.login = { provider, user };
   return Promise.resolve();
 }
 
-export function getUser({ login } = {}) {
+export function getUser({ login } = null) {
   logger.debug(`[model:login] get login user from session [${login}].`);
-
-  if (!login) {
-    return null;
-  }
-
-  // TODO change to store meaningful object to session
-  const [provider, user] = login.substring(1).split('/');
-  return { provider, user };
+  return login;
 }
 
-export function validate({ url, session: { login } }) {
-  logger.debug(`[model:login] validate request [${url}] with session login ${JSON.stringify(login)}.`);
+export function validate({ provider, user, session: { login = {} } }) {
+  logger.debug(`[model:login] validate [${provider}/${user}] request with session login ${JSON.stringify(login)}.`);
   return new Promise((resolve, reject) => {
-    if (url.indexOf(login) === 0 || url.indexOf(`/token${login}`) === 0) {
-      logger.debug(`[model:login] validate request [${url}] succeed, move to next middleware.`);
+    if (provider === login.provider && user === login.user) {
+      logger.debug(`[model:login] validate [${provider}/${user}] request succeed.`);
       resolve();
     } else {
-      logger.info(`[model:login] validate request [${url}] fail.`);
+      logger.info(`[model:login] validate [${provider}/${user}] request fail.`);
       reject({
         code: 401,
         message: 'Unanthorized, please login in.',

--- a/src/routes/home/index.js
+++ b/src/routes/home/index.js
@@ -9,13 +9,8 @@ export const model = ({ session }) => {
   const login = loginModel.getUser(session);
   logger.debug(`[routes:home] get login user ${JSON.stringify(login)}`);
 
-  return Promise.resolve(
-    !login
-    ? {}
-    : {
-      login,
-      url: {
-        repoList: `/${login.provider}/${login.user}`,
-      },
-    });
+  return Promise.resolve({
+    login,
+    repoListUrl: login ? `/${login.provider}/${login.user}` : null,
+  });
 };

--- a/src/routes/repo/index.js
+++ b/src/routes/repo/index.js
@@ -32,10 +32,10 @@ function filterInvalid(provider, user, repos) {
   }));
 }
 
-export function model({ url, session, params: { provider, user } }) {
+export function model({ session, params: { provider, user } }) {
   logger.debug(`[routes:repo] prepare repo list for provider [${provider}], user [${user}].`);
 
-  return loginModel.validate({ url, session })
+  return loginModel.validate({ provider, user, session })
   .then(() => repoModel.query({ provider, user }))
   .then(repos => ({
     provider,

--- a/src/routes/repo/report.js
+++ b/src/routes/repo/report.js
@@ -8,11 +8,10 @@ export const route = '/:provider/:user/:repo';
 export const view = 'repo';
 
 export function model({
-    url,
     session,
     params: { provider, user, repo },
   }) {
-  return loginModel.validate({ url, session })
+  return loginModel.validate({ provider, user, session })
   .then(() => Promise.all([
     reportModel.query({ provider, user, repo }),
     tokenModel.get({ provider, user, repo }).catch(() => undefined),

--- a/src/routes/token/index.js
+++ b/src/routes/token/index.js
@@ -4,8 +4,8 @@ import * as tokenModel from '../../models/token';
 
 export const route = '/token/:provider/:user/:repo';
 
-export function post({ url, session, params: { provider, user, repo } }) {
+export function post({ session, params: { provider, user, repo } }) {
   logger.debug(`[routes:token] post to create token for provider [${provider}], user [${user}] and repo [${repo}].`);
-  return loginModel.validate({ url, session })
+  return loginModel.validate({ provider, user, session })
   .then(() => tokenModel.create({ provider, user, repo }));
 }

--- a/src/views/home.js
+++ b/src/views/home.js
@@ -23,9 +23,9 @@ const Login = () => (
   </p>
 );
 
-const Welcome = ({ login, url }) => (
+const Welcome = ({ login, repoListUrl }) => (
   <p>
-    Logged in as <mark>{login.provider}/{login.user}</mark>. Go to <a href={url.repoList}>repository list</a>.
+    Logged in as <mark>{login.provider}/{login.user}</mark>. Go to <a href={repoListUrl}>repository list</a>.
   </p>
 );
 

--- a/test/e2e/home/index.js
+++ b/test/e2e/home/index.js
@@ -18,7 +18,10 @@ describe('/', () => {
   it('should render welcome and go to repo link if user login', done =>
     stub({
       session: {
-        login: '/e2e/tester',
+        login: {
+          provider: 'e2e',
+          user: 'tester',
+        },
       },
     })
     .get('/')

--- a/test/e2e/repo/index.js
+++ b/test/e2e/repo/index.js
@@ -26,7 +26,10 @@ describe('/provider/user', () =>
 
     stub({
       session: {
-        login: '/e2e/tester',
+        login: {
+          provider: 'e2e',
+          user: 'tester',
+        },
       },
       table: {
         query: tableQuery,

--- a/test/e2e/repo/report.js
+++ b/test/e2e/repo/report.js
@@ -18,7 +18,10 @@ describe('/provider/user/repo', () => {
 
     stub({
       session: {
-        login: '/e2e/tester',
+        login: {
+          provider: 'e2e',
+          user: 'tester',
+        },
       },
       table: {
         query,
@@ -51,7 +54,10 @@ describe('/provider/user/repo', () => {
 
     stub({
       session: {
-        login: '/e2e/tester',
+        login: {
+          provider: 'e2e',
+          user: 'tester',
+        },
       },
       table: {
         query,

--- a/test/e2e/token/index.js
+++ b/test/e2e/token/index.js
@@ -9,7 +9,10 @@ describe('/token/provider/user/repo', () =>
 
     stub({
       session: {
-        login: '/e2e/tester',
+        login: {
+          provider: 'e2e',
+          user: 'tester',
+        },
       },
       table: { insert },
     })

--- a/test/models/login.js
+++ b/test/models/login.js
@@ -1,0 +1,32 @@
+/* global describe, it */
+
+import 'should';
+import model from '../utils/model';
+
+describe('model login', () => {
+  it('should pass validation when user match', () =>
+    model('login').validate({
+      provider: 'models',
+      user: 'tester',
+      session: {
+        login: {
+          provider: 'models',
+          user: 'tester',
+        },
+      },
+    })
+    .then(() => 'everything'.should.be.ok()));
+
+  it('should fail validation when user not match', () =>
+    model('login').validate({
+      provider: 'models',
+      user: 'hacker',
+      session: {
+        login: {
+          provider: 'models',
+          user: 'tester',
+        },
+      },
+    })
+    .catch(error => error.should.have.properties(['code', 'message'])));
+});

--- a/test/routes/home/index.js
+++ b/test/routes/home/index.js
@@ -13,7 +13,11 @@ describe('route home', () => {
       },
     });
 
-    return home.model({}).then(result => result.should.eql({}));
+    return home.model({})
+    .then(result => result.should.have.properties({
+      login: null,
+      repoListUrl: null,
+    }));
   });
 
   it('should return login information if login', () => {
@@ -30,9 +34,10 @@ describe('route home', () => {
       },
     });
 
-    return home.model({}).then(result => {
-      result.login.should.eql(login);
-      result.url.repoList.should.not.be.empty();
-    });
+    return home.model({})
+    .then(result => result.should.have.properties({
+      login,
+      repoListUrl: '/routes/tester',
+    }));
   });
 });

--- a/test/utils/model.js
+++ b/test/utils/model.js
@@ -1,0 +1,10 @@
+import proxyquire from 'proxyquire';
+import logger from './logger';
+
+export default function model(name) {
+  return proxyquire(`../../src/models/${name}`, {
+    '../services': {
+      logger,
+    },
+  });
+}

--- a/test/views/home.js
+++ b/test/views/home.js
@@ -33,15 +33,13 @@ describe('view home', () => {
         provider: 'views',
         user: 'tester',
       },
-      url: {
-        repoList: '/repo/list',
-      },
+      repoListUrl: '/repo/list',
     };
 
     const query = view('home', properties);
 
     const anchor = query('body a');
-    anchor.attr('href').should.equal(properties.url.repoList);
+    anchor.attr('href').should.equal(properties.repoListUrl);
 
     const paragraph = query('body p');
     paragraph.text().should.containEql('Logged in')


### PR DESCRIPTION
- Login session validation base on route variables, not URL now.
- Refine the home page `repoListUrl`.
- Update the related E2E test fixtures.