### PR TITLE
Convert URL builder - avoid URL hard code.

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "express-session": "^1.11.3",
     "locallydb": "0.0.9",
     "node-uuid": "^1.4.3",
+    "path-to-regexp": "^1.2.1",
     "react": "^0.14.0",
     "react-dom": "^0.14.0",
     "request": "^2.65.0",

--- a/src/routes/home/index.js
+++ b/src/routes/home/index.js
@@ -1,5 +1,6 @@
 import * as loginModel from '../../models/login';
 import { logger } from '../../services';
+import { url as repoUrl } from '../repo';
 
 export const route = '/';
 
@@ -11,6 +12,6 @@ export const model = ({ session }) => {
 
   return Promise.resolve({
     login,
-    repoListUrl: login ? `/${login.provider}/${login.user}` : null,
+    repoListUrl: login ? repoUrl(login) : null,
   });
 };

--- a/src/routes/login/callback.js
+++ b/src/routes/login/callback.js
@@ -1,5 +1,6 @@
 import { logger } from '../../services';
 import { getProvider } from '../../providers';
+import { url as repoUrl } from '../repo';
 import * as loginModel from '../../models/login';
 
 export const route = '/login/:provider/callback';
@@ -8,6 +9,6 @@ export function redirect({ params: { provider }, query: { code }, session }) {
   logger.debug(`[routes:login:callback] prepare user redirect URL from provider [${provider}] with code [${code}].`);
   const getUser = getProvider(provider).getUser(code);
   const setLogin = getUser.then(user => loginModel.set({ session, provider, user }));
-  const getUserUrl = getUser.then(user => `/${provider}/${user}`);
+  const getUserUrl = getUser.then(user => repoUrl({ provider, user }));
   return Promise.all([getUserUrl, setLogin]).then(([url]) => url);
 }

--- a/src/routes/repo/index.js
+++ b/src/routes/repo/index.js
@@ -1,8 +1,11 @@
+import { compile } from 'path-to-regexp';
 import { logger } from '../../services';
 import * as repoModel from '../../models/repo';
 import * as loginModel from '../../models/login';
 
 export const route = '/:provider/:user';
+
+export const url = compile(route);
 
 export const view = 'repo-list';
 

--- a/src/routes/repo/index.js
+++ b/src/routes/repo/index.js
@@ -1,5 +1,6 @@
 import { compile } from 'path-to-regexp';
 import { logger } from '../../services';
+import { url as reportUrl } from './report';
 import { url as badgeUrl } from '../report/svg';
 import * as repoModel from '../../models/repo';
 import * as loginModel from '../../models/login';
@@ -15,7 +16,11 @@ function filterEnabled(provider, user, repos) {
     ...repo,
     token: undefined, // hide token from this view model
     enabled: true,
-    repoUrl: `/${provider}/${user}/${repo.name}`,
+    repoUrl: reportUrl({
+      provider,
+      user,
+      repo: repo.name,
+    }),
     badgeUrl: badgeUrl({
       provider,
       user,
@@ -28,14 +33,22 @@ function filterEnabled(provider, user, repos) {
 function filterDisabled(provider, user, repos) {
   return repos.filter(repo => !repo.token && !repo.invalid).map(repo => ({
     ...repo,
-    repoUrl: `/${provider}/${user}/${repo.name}`,
+    repoUrl: reportUrl({
+      provider,
+      user,
+      repo: repo.name,
+    }),
   }));
 }
 
 function filterInvalid(provider, user, repos) {
   return repos.filter(repo => repo.invalid).map(repo => ({
     ...repo,
-    repoUrl: `/${provider}/${user}/${repo.name}`,
+    repoUrl: reportUrl({
+      provider,
+      user,
+      repo: repo.name,
+    }),
   }));
 }
 

--- a/src/routes/repo/index.js
+++ b/src/routes/repo/index.js
@@ -1,5 +1,6 @@
 import { compile } from 'path-to-regexp';
 import { logger } from '../../services';
+import { url as badgeUrl } from '../report/svg';
 import * as repoModel from '../../models/repo';
 import * as loginModel from '../../models/login';
 
@@ -15,9 +16,12 @@ function filterEnabled(provider, user, repos) {
     token: undefined, // hide token from this view model
     enabled: true,
     repoUrl: `/${provider}/${user}/${repo.name}`,
-
-    // TODO query master branch from provider
-    badgeUrl: `/${provider}/${user}/${repo.name}/master.svg`,
+    badgeUrl: badgeUrl({
+      provider,
+      user,
+      repo: repo.name,
+      branch: 'master', // TODO query master branch from provider
+    }),
   }));
 }
 

--- a/src/routes/repo/report.js
+++ b/src/routes/repo/report.js
@@ -1,10 +1,13 @@
 import bodyParser from 'body-parser';
+import { compile } from 'path-to-regexp';
 import * as loginModel from '../../models/login';
 import * as tokenModel from '../../models/token';
 import * as reportModel from '../../models/report';
 import { url as badgeUrl } from '../report/svg';
 
 export const route = '/:provider/:user/:repo';
+
+export const url = compile(route);
 
 export const view = 'repo';
 

--- a/src/routes/repo/report.js
+++ b/src/routes/repo/report.js
@@ -2,6 +2,7 @@ import bodyParser from 'body-parser';
 import * as loginModel from '../../models/login';
 import * as tokenModel from '../../models/token';
 import * as reportModel from '../../models/report';
+import { url as badgeUrl } from '../report/svg';
 
 export const route = '/:provider/:user/:repo';
 
@@ -27,9 +28,13 @@ export function model({
       caption: report.report
         ? `${report.branch}/${report.report}`
         : report.branch,
-      badgeUrl: report.report
-        ? `/${provider}/${user}/${repo}/${report.branch}/${report.report}.svg`
-        : `/${provider}/${user}/${repo}/${report.branch}.svg`,
+      badgeUrl: badgeUrl({
+        provider,
+        user,
+        repo,
+        branch: report.branch,
+        report: report.report,
+      }),
     })),
   }));
 }

--- a/src/routes/repo/report.js
+++ b/src/routes/repo/report.js
@@ -4,6 +4,7 @@ import * as loginModel from '../../models/login';
 import * as tokenModel from '../../models/token';
 import * as reportModel from '../../models/report';
 import { url as badgeUrl } from '../report/svg';
+import { url as tokenUrl } from '../token';
 
 export const route = '/:provider/:user/:repo';
 
@@ -25,7 +26,11 @@ export function model({
     user,
     repo,
     token,
-    tokenUrl: `/token/${provider}/${user}/${repo}`,
+    tokenUrl: tokenUrl({
+      provider,
+      user,
+      repo,
+    }),
     reports: reports.map(report => ({
       ...report,
       caption: report.report

--- a/src/routes/report/svg.js
+++ b/src/routes/report/svg.js
@@ -1,7 +1,15 @@
+import { compile } from 'path-to-regexp';
 import { logger } from '../../services';
 import * as reportModel from '../../models/report';
 
 export const route = '/:provider/:user/:repo/:branch/:report?.svg';
+
+const build = compile(route);
+export const url = (opts) => {
+  // not generate report segment if it is empty name
+  if (!opts.report) opts.report = undefined;
+  return build(opts);
+};
 
 export const type = 'svg';
 

--- a/src/routes/token/index.js
+++ b/src/routes/token/index.js
@@ -1,8 +1,11 @@
+import { compile } from 'path-to-regexp';
 import { logger } from '../../services';
 import * as loginModel from '../../models/login';
 import * as tokenModel from '../../models/token';
 
 export const route = '/token/:provider/:user/:repo';
+
+export const url = compile(route);
 
 export function post({ session, params: { provider, user, repo } }) {
   logger.debug(`[routes:token] post to create token for provider [${provider}], user [${user}] and repo [${repo}].`);


### PR DESCRIPTION
- Leverage path-to-regexp to generate URL from route.
- Update all hard coded URL to URL builder.
- No need to update test codes.