### PR TITLE
Make URL builder in route index.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,7 @@
 {
   "extends": "airbnb",
   "rules": {
+    "react/no-multi-comp": 0,
     "react/prop-types": 0
   }
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,7 +4,7 @@ import gulp from 'gulp';
 import eslint from 'gulp-eslint';
 import babel from 'gulp-babel';
 import writeFile from './build/write-file';
-import generateRoutes from './src/routes/generate';
+import { generateRoutes } from './src/routes/generate';
 
 import './build/azure';
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "express-session": "^1.11.3",
     "file": "^0.2.2",
     "locallydb": "0.0.9",
+    "lodash": "^3.10.1",
     "marked": "^0.3.5",
     "node-uuid": "^1.4.3",
     "path-to-regexp": "^1.2.1",

--- a/src/routes/generate.js
+++ b/src/routes/generate.js
@@ -1,15 +1,31 @@
 import file from 'file';
+import { set } from 'lodash';
+import { compile } from 'path-to-regexp';
 
-export default function generateRoutes() {
+const startIndex = __dirname.length + 1;
+
+function toRoute(dirPath, name) {
+  const prefix = dirPath.substring(startIndex);
+  const basename = name.slice(0, -3); // strip .js extension
+  return `${prefix}/${basename}`;
+}
+
+export function generateRoutes() {
   let routes = [];
-  const startIndex = __dirname.length + 1;
 
-  file.walkSync(__dirname, (dirPath, dirs, files) => {
+  file.walkSync(__dirname, (dirPath, dirs, files) =>
     routes = routes.concat(
       dirPath !== __dirname
-      ? files.map(name => `${dirPath}/${name}`.substring(startIndex))
-      : []);
-  });
+      ? files.map(name => toRoute(dirPath, name))
+      : []));
 
   return routes;
+}
+
+export function generateUrls(modules) {
+  return modules.reduce((object, { name, module }) => {
+    const path = name.replace('/', '.'); // convert name to object path
+    const route = compile(module.route);
+    return set(object, path, route);
+  }, {});
 }

--- a/src/routes/home/index.js
+++ b/src/routes/home/index.js
@@ -1,17 +1,16 @@
 import * as loginModel from '../../models/login';
 import { logger } from '../../services';
-import { url as repoUrl } from '../repo';
 
 export const route = '/';
 
 export const view = 'home';
 
-export const model = ({ session }) => {
+export const model = ({ session, urls }) => {
   const login = loginModel.getUser(session);
   logger.debug(`[routes:home] get login user ${JSON.stringify(login)}`);
 
   return Promise.resolve({
     login,
-    repoListUrl: login ? repoUrl(login) : null,
+    repoListUrl: login ? urls.repo.index(login) : null,
   });
 };

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -23,9 +23,9 @@ function register(router, route, name, method) {
 function createRouter() {
   const router = new express.Router();
   const routes = config.generate ? generateRoutes() : config.routes;
+  const modules = routes.map(name => ({ name, module: require(`./${name}`) }));
 
-  routes.forEach(name => {
-    const module = require(`./${name}`);
+  modules.forEach(({ name, module }) => {
     const get = register(router, module.route, name, 'get');
     const post = register(router, module.route, name, 'post');
 

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,7 +1,7 @@
 import express from 'express';
 import config from './routes';
-import generateRoutes from './generate';
 import { logger } from '../services';
+import { generateRoutes, generateUrls } from './generate';
 
 function handleError(res) {
   return (error) => {
@@ -24,6 +24,7 @@ function createRouter() {
   const router = new express.Router();
   const routes = config.generate ? generateRoutes() : config.routes;
   const modules = routes.map(name => ({ name, module: require(`./${name}`) }));
+  const urls = generateUrls(modules);
 
   modules.forEach(({ name, module }) => {
     const get = register(router, module.route, name, 'get');
@@ -33,7 +34,7 @@ function createRouter() {
 
     if (module.post) {
       post(module.post.middlewares, (req, res) =>
-        module.post(req).then(result =>
+        module.post({ ...req, urls }).then(result =>
           // TODO leverage `res.format` to better content-negotiation
           req.accepts('html') === 'html'
           ? res.redirect(req.get('Referer'))
@@ -42,10 +43,10 @@ function createRouter() {
 
     if (module.redirect) {
       get(module.redirect.middlewares, (req, res) =>
-        module.redirect(req).then(url => res.redirect(url)));
+        module.redirect({ ...req, urls }).then(url => res.redirect(url)));
     } else if (module.view && module.model) {
       get(module.model.middlewares, (req, res) =>
-        module.model(req).then(model =>
+        module.model({ ...req, urls }).then(model =>
           res.type(module.type || 'html').render(module.view, model)));
     }
   });

--- a/src/routes/login/callback.js
+++ b/src/routes/login/callback.js
@@ -1,14 +1,13 @@
 import { logger } from '../../services';
 import { getProvider } from '../../providers';
-import { url as repoUrl } from '../repo';
 import * as loginModel from '../../models/login';
 
 export const route = '/login/:provider/callback';
 
-export function redirect({ params: { provider }, query: { code }, session }) {
+export function redirect({ params: { provider }, query: { code }, session, urls }) {
   logger.debug(`[routes:login:callback] prepare user redirect URL from provider [${provider}] with code [${code}].`);
   const getUser = getProvider(provider).getUser(code);
   const setLogin = getUser.then(user => loginModel.set({ session, provider, user }));
-  const getUserUrl = getUser.then(user => repoUrl({ provider, user }));
+  const getUserUrl = getUser.then(user => urls.repo.index({ provider, user }));
   return Promise.all([getUserUrl, setLogin]).then(([url]) => url);
 }

--- a/src/routes/repo/index.js
+++ b/src/routes/repo/index.js
@@ -1,11 +1,8 @@
-import { compile } from 'path-to-regexp';
 import { logger } from '../../services';
 import * as repoModel from '../../models/repo';
 import * as loginModel from '../../models/login';
 
 export const route = '/:provider/:user';
-
-export const url = compile(route);
 
 export const view = 'repo-list';
 

--- a/src/routes/repo/index.js
+++ b/src/routes/repo/index.js
@@ -1,7 +1,5 @@
 import { compile } from 'path-to-regexp';
 import { logger } from '../../services';
-import { url as reportUrl } from './report';
-import { url as badgeUrl } from '../report/svg';
 import * as repoModel from '../../models/repo';
 import * as loginModel from '../../models/login';
 
@@ -11,17 +9,17 @@ export const url = compile(route);
 
 export const view = 'repo-list';
 
-function filterEnabled(provider, user, repos) {
+function filterEnabled(provider, user, repos, urls) {
   return repos.filter(repo => repo.token && !repo.invalid).map(repo => ({
     ...repo,
     token: undefined, // hide token from this view model
     enabled: true,
-    repoUrl: reportUrl({
+    repoUrl: urls.repo.report({
       provider,
       user,
       repo: repo.name,
     }),
-    badgeUrl: badgeUrl({
+    badgeUrl: urls.report.svg({
       provider,
       user,
       repo: repo.name,
@@ -30,10 +28,10 @@ function filterEnabled(provider, user, repos) {
   }));
 }
 
-function filterDisabled(provider, user, repos) {
+function filterDisabled(provider, user, repos, urls) {
   return repos.filter(repo => !repo.token && !repo.invalid).map(repo => ({
     ...repo,
-    repoUrl: reportUrl({
+    repoUrl: urls.repo.report({
       provider,
       user,
       repo: repo.name,
@@ -41,10 +39,10 @@ function filterDisabled(provider, user, repos) {
   }));
 }
 
-function filterInvalid(provider, user, repos) {
+function filterInvalid(provider, user, repos, urls) {
   return repos.filter(repo => repo.invalid).map(repo => ({
     ...repo,
-    repoUrl: reportUrl({
+    repoUrl: urls.repo.report({
       provider,
       user,
       repo: repo.name,
@@ -52,7 +50,7 @@ function filterInvalid(provider, user, repos) {
   }));
 }
 
-export function model({ session, params: { provider, user } }) {
+export function model({ urls, session, params: { provider, user } }) {
   logger.debug(`[routes:repo] prepare repo list for provider [${provider}], user [${user}].`);
 
   return loginModel.validate({ provider, user, session })
@@ -60,8 +58,8 @@ export function model({ session, params: { provider, user } }) {
   .then(repos => ({
     provider,
     user,
-    enabled: filterEnabled(provider, user, repos),
-    disabled: filterDisabled(provider, user, repos),
-    invalid: filterInvalid(provider, user, repos),
+    enabled: filterEnabled(provider, user, repos, urls),
+    disabled: filterDisabled(provider, user, repos, urls),
+    invalid: filterInvalid(provider, user, repos, urls),
   }));
 }

--- a/src/routes/repo/report.js
+++ b/src/routes/repo/report.js
@@ -1,12 +1,9 @@
 import bodyParser from 'body-parser';
-import { compile } from 'path-to-regexp';
 import * as loginModel from '../../models/login';
 import * as tokenModel from '../../models/token';
 import * as reportModel from '../../models/report';
 
 export const route = '/:provider/:user/:repo';
-
-export const url = compile(route);
 
 export const view = 'repo';
 

--- a/src/routes/repo/report.js
+++ b/src/routes/repo/report.js
@@ -3,8 +3,6 @@ import { compile } from 'path-to-regexp';
 import * as loginModel from '../../models/login';
 import * as tokenModel from '../../models/token';
 import * as reportModel from '../../models/report';
-import { url as badgeUrl } from '../report/svg';
-import { url as tokenUrl } from '../token';
 
 export const route = '/:provider/:user/:repo';
 
@@ -13,6 +11,7 @@ export const url = compile(route);
 export const view = 'repo';
 
 export function model({
+    urls,
     session,
     params: { provider, user, repo },
   }) {
@@ -26,7 +25,7 @@ export function model({
     user,
     repo,
     token,
-    tokenUrl: tokenUrl({
+    tokenUrl: urls.token.index({
       provider,
       user,
       repo,
@@ -36,12 +35,12 @@ export function model({
       caption: report.report
         ? `${report.branch}/${report.report}`
         : report.branch,
-      badgeUrl: badgeUrl({
+      badgeUrl: urls.report.svg({
         provider,
         user,
         repo,
         branch: report.branch,
-        report: report.report,
+        report: report.report || undefined,
       }),
     })),
   }));

--- a/src/routes/report/svg.js
+++ b/src/routes/report/svg.js
@@ -1,15 +1,7 @@
-import { compile } from 'path-to-regexp';
 import { logger } from '../../services';
 import * as reportModel from '../../models/report';
 
 export const route = '/:provider/:user/:repo/:branch/:report?.svg';
-
-const build = compile(route);
-export const url = (opts) => {
-  // not generate report segment if it is empty name
-  if (!opts.report) opts.report = undefined;
-  return build(opts);
-};
 
 export const type = 'svg';
 

--- a/src/routes/token/index.js
+++ b/src/routes/token/index.js
@@ -1,11 +1,8 @@
-import { compile } from 'path-to-regexp';
 import { logger } from '../../services';
 import * as loginModel from '../../models/login';
 import * as tokenModel from '../../models/token';
 
 export const route = '/token/:provider/:user/:repo';
-
-export const url = compile(route);
 
 export function post({ session, params: { provider, user, repo } }) {
   logger.debug(`[routes:token] post to create token for provider [${provider}], user [${user}] and repo [${repo}].`);

--- a/test/routes/home/index.js
+++ b/test/routes/home/index.js
@@ -1,6 +1,7 @@
 /* global describe, it */
 
 import 'should';
+import urls from '../../utils/urls';
 import route from '../../utils/route';
 
 describe('route home', () => {
@@ -13,7 +14,7 @@ describe('route home', () => {
       },
     });
 
-    return home.model({})
+    return home.model({ urls })
     .then(result => result.should.have.properties({
       login: null,
       repoListUrl: null,
@@ -34,7 +35,7 @@ describe('route home', () => {
       },
     });
 
-    return home.model({})
+    return home.model({ urls })
     .then(result => result.should.have.properties({
       login,
       repoListUrl: '/routes/tester',

--- a/test/routes/repo/index.js
+++ b/test/routes/repo/index.js
@@ -1,6 +1,7 @@
 /* global describe, it */
 
 import 'should';
+import urls from '../../utils/urls';
 import route from '../../utils/route';
 import mockFunction from '../../utils/mock-function';
 
@@ -45,7 +46,7 @@ describe('route repo index', () => {
       },
     });
 
-    return repo.model({ params: info })
+    return repo.model({ urls, params: info })
     .then(model => {
       model.should.have.properties(info);
       model.should.have.property('enabled').have.length(3);

--- a/test/routes/repo/report.js
+++ b/test/routes/repo/report.js
@@ -1,6 +1,7 @@
 /* global describe, it */
 
 import 'should';
+import urls from '../../utils/urls';
 import route from '../../utils/route';
 import mockFunction from '../../utils/mock-function';
 
@@ -28,7 +29,7 @@ describe('route repo report', () => {
       },
     });
 
-    return repo.model({ params: info })
+    return repo.model({ urls, params: info })
     .then(model => model.should.have.properties(info)
       .and.have.properties({ token: 'project-token' })
       .and.have.property('reports').have.length(0))
@@ -61,7 +62,7 @@ describe('route repo report', () => {
       },
     });
 
-    return repo.model({ params: info })
+    return repo.model({ urls, params: info })
     .then(model => {
       model.reports.should.have.length(2);
 
@@ -98,7 +99,7 @@ describe('route repo report', () => {
       },
     });
 
-    return repo.model({ params: info })
+    return repo.model({ urls, params: info })
     .then(model => model.should.have.properties({
       token: undefined,
       tokenUrl: '/token/routes/tester/project',

--- a/test/utils/urls.js
+++ b/test/utils/urls.js
@@ -1,0 +1,14 @@
+import { generateRoutes, generateUrls } from '../../src/routes/generate';
+
+function requireRoute(name) {
+  return require(`../../src/routes/${name}`);
+}
+
+function constructUrls() {
+  const routes = generateRoutes();
+  const modules = routes.map(name => ({ name, module: requireRoute(name) }));
+  const urls = generateUrls(modules);
+  return urls;
+}
+
+export default constructUrls();


### PR DESCRIPTION
- Make URL builder in route index and pass into routes as parameter.
- Update the URL build logic to leverage the pass-in URL builders.
- Refine the generate routes logic, to strip the `.js` extension.
- Update the route test cases to pass in the URL builders.